### PR TITLE
优化 CardListItem 组件渲染性能

### DIFF
--- a/src/renderer/views/Gacha/components/CardListItem.vue
+++ b/src/renderer/views/Gacha/components/CardListItem.vue
@@ -29,6 +29,8 @@ defineProps(['item']);
     box-shadow: 1px 1px 2px #0003;
     flex-shrink: 0;
     overflow: hidden;
+    content-visibility: auto;
+    contain-intrinsic-size: 40px;
 
     & > div {
         position: absolute;
@@ -47,6 +49,7 @@ defineProps(['item']);
         inset: -50px;
         background: repeating-linear-gradient(45deg, transparent 0px 18px, #fff3 18px 32px);
         animation: bg-bar-mask-anim 5s linear infinite;
+        will-change: transform;
     }
 }
 
@@ -110,11 +113,10 @@ defineProps(['item']);
 
 @keyframes bg-bar-mask-anim {
     from {
-        background-position: 0;
+        transform: translateX(0);
     }
-
     to {
-        background-position: 45px;
+        transform: translateX(45px);
     }
 }
 </style>


### PR DESCRIPTION
当以分类展示抽卡记录，并且展开成条形统计图，就会出现 `CardListItem` 频繁触发浏览器重绘的问题，产生非常高的 CPU 占用。

本 PR 通过使用 transform 代替 background-position，显著降低了渲染压力。

性能对比如图所示：

<img width="609" height="123" alt="PixPin_2026-03-18_21-35-30" src="https://github.com/user-attachments/assets/4413942e-819f-4585-a6dc-03cb423c083a" />
<img width="613" height="111" alt="PixPin_2026-03-18_21-36-13" src="https://github.com/user-attachments/assets/a196c5f4-ed6b-414a-8205-5a8b9718d7c8" />
