### PR TITLE
feat: 支持国际服跃迁记录与成就导入

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2,7 +2,7 @@ import { app, BrowserWindow, Tray, Menu, ipcMain, shell } from 'electron';
 import path from 'path';
 import fs from 'fs';
 
-import settingService from './service/SettingService';
+import settingService from './service/settingService';
 
 // 禁用硬件加速
 app.disableHardwareAcceleration();

--- a/src/main/service/achievementService.ts
+++ b/src/main/service/achievementService.ts
@@ -1,6 +1,6 @@
 import { app, BrowserWindow, dialog } from 'electron';
-import configService from './ConfigService';
-import settingService from './SettingService';
+import configService from './configService';
+import settingService from './settingService';
 import path from 'path';
 import fs from 'fs';
 

--- a/src/main/service/achievementService.ts
+++ b/src/main/service/achievementService.ts
@@ -4,6 +4,17 @@ import settingService from './settingService';
 import path from 'path';
 import fs from 'fs';
 
+const serverConfigs = {
+    cn: {
+        pageURL: 'https://act.mihoyo.com/sr/event/cultivation-tool/index.html#/tools/achievement',
+        requestURLs: ['*://*.mihoyo.com/event/rpgcultivate/achievement/list*'],
+    },
+    global: {
+        pageURL: 'https://act.hoyolab.com/sr/event/cultivation-tool/index.html?game_biz=hkrpg_global&hyl_auth_required=true#/tools/achievement',
+        requestURLs: ['*://*.hoyolab.com/event/rpgcultivate/achievement/list*', '*://*.hoyoverse.com/event/rpgcultivate/achievement/list*'],
+    },
+};
+
 class AchievementService {
     private appDataPath: string;
     private achievementDataPath: string;
@@ -33,6 +44,44 @@ class AchievementService {
                 return sortedObj;
             }, {});
         fs.writeFileSync(this.achievementUidsPath, JSON.stringify(this.achievementUids, null, 4), 'utf-8');
+    }
+
+    private getAchievementUid(url: string, data: unknown) {
+        const params = new URL(url).searchParams;
+        const uid = params.get('badge_uid') ?? params.get('game_uid') ?? params.get('uid') ?? params.get('role_id') ?? data?.['data']?.['uid'] ?? data?.['data']?.['role']?.['game_uid'] ?? '';
+        return `${uid}`;
+    }
+
+    private async saveRefreshedAchievements(uid: string, achievementList: Array<{ finished: boolean; id: string }>) {
+        if (!/^\d{9}$/.test(uid)) return { msg: 'Invalid UID' };
+        if (this.achievementUids[uid] === undefined) {
+            await this.newAchievementData(uid, 'Trailblazer');
+        }
+        await settingService.setAppSettings('LastAchievementUid', uid);
+        const achievementMetaIds = new Set(Object.keys(JSON.parse(fs.readFileSync(path.join(__dirname, '../static/json/AchievementData.json'), 'utf-8'))));
+        const finishedIds = [];
+        achievementList.forEach((achievement) => {
+            if (achievement.finished && achievementMetaIds.has(achievement.id)) {
+                finishedIds.push(achievement.id);
+            }
+        });
+        const oldData = JSON.parse(fs.readFileSync(path.join(this.achievementDataPath, `./${uid}.json`), 'utf-8'));
+        const newData = {};
+        const timeNow = Math.floor(new Date().getTime() / 1000);
+        finishedIds.forEach((achievementId) => {
+            if (oldData[achievementId] === undefined) {
+                newData[achievementId] = {
+                    id: achievementId,
+                    timestamp: timeNow,
+                    current: 0,
+                    status: 2,
+                };
+            } else {
+                newData[achievementId] = oldData[achievementId];
+            }
+        });
+        fs.writeFileSync(path.join(this.achievementDataPath, `./${uid}.json`), JSON.stringify(newData, null, 4), 'utf-8');
+        return { msg: 'OK', data: uid };
     }
 
     public async getAchievementUids() {
@@ -184,8 +233,13 @@ class AchievementService {
         return { msg: 'OK', data: ret };
     }
 
-    public async refreshAchievementFromMYS(keepCookie = false) {
+    public async refreshAchievementFromMYS(keepCookie = false, server = 'cn') {
         return new Promise(async (resolve) => {
+            const serverConfig = serverConfigs[server];
+            if (serverConfig === undefined) {
+                resolve({ msg: 'Unsupport server' });
+                return;
+            }
             this.mysBrowserWindow = new BrowserWindow({
                 width: 720,
                 height: 480,
@@ -197,49 +251,31 @@ class AchievementService {
                 resolve('Canceled');
             });
             if (!keepCookie) await this.mysBrowserWindow.webContents.session.clearStorageData({ storages: ['cookies'] });
-            this.mysBrowserWindow.loadURL('https://act.mihoyo.com/sr/event/cultivation-tool/index.html#/tools/achievement');
+            this.mysBrowserWindow.loadURL(serverConfig.pageURL);
             let flag = false;
-            this.mysBrowserWindow.webContents.session.webRequest.onBeforeSendHeaders({ urls: ['*://*.mihoyo.com/event/rpgcultivate/achievement/list*'] }, (details, callback) => {
+            this.mysBrowserWindow.webContents.session.webRequest.onBeforeSendHeaders({ urls: serverConfig.requestURLs }, (details, callback) => {
                 if (details.method === 'OPTIONS') return callback({});
                 if (flag) return callback({});
                 flag = true;
-                const newURL = details.url.replace('need_all=false', 'need_all=true').replace('show_hide=false', 'show_hide=true');
+                const urlObj = new URL(details.url);
+                urlObj.searchParams.set('need_all', 'true');
+                urlObj.searchParams.set('show_hide', 'true');
+                const newURL = urlObj.href;
                 fetch(newURL, { headers: details.requestHeaders })
                     .then((response) => response.json())
                     .then(async (data) => {
                         if (data.retcode === 0) {
-                            const uid = newURL.match(/badge_uid=(\d+)/)[1];
-                            if (this.achievementUids[uid] === undefined) {
-                                await this.newAchievementData(uid, 'Trailblazer');
-                            }
-                            await settingService.setAppSettings('LastAchievementUid', uid);
-                            const achievementMetaIds = new Set(Object.keys(JSON.parse(fs.readFileSync(path.join(__dirname, '../static/json/AchievementData.json'), 'utf-8'))));
-                            const finishedIds = [];
-                            data.data.achievement_list.forEach((achievement: { finished: boolean; id: string }) => {
-                                if (achievement.finished && achievementMetaIds.has(achievement.id)) {
-                                    finishedIds.push(achievement.id);
-                                }
-                            });
-                            const oldData = JSON.parse(fs.readFileSync(path.join(this.achievementDataPath, `./${uid}.json`), 'utf-8'));
-                            const newData = {};
-                            const timeNow = Math.floor(new Date().getTime() / 1000);
-                            finishedIds.forEach((achievementId) => {
-                                if (oldData[achievementId] === undefined) {
-                                    newData[achievementId] = {
-                                        id: achievementId,
-                                        timestamp: timeNow,
-                                        current: 0,
-                                        status: 2,
-                                    };
-                                } else {
-                                    newData[achievementId] = oldData[achievementId];
-                                }
-                            });
-                            fs.writeFileSync(path.join(this.achievementDataPath, `./${uid}.json`), JSON.stringify(newData, null, 4), 'utf-8');
-                            resolve(uid);
+                            const uid = this.getAchievementUid(newURL, data);
+                            const ret = await this.saveRefreshedAchievements(uid, data.data.achievement_list ?? []);
+                            resolve(ret['msg'] === 'OK' ? ret['data'] : ret);
                         } else {
                             resolve(data);
                         }
+                        this.mysBrowserWindow?.close();
+                        this.mysBrowserWindow = null;
+                    })
+                    .catch((error) => {
+                        resolve({ msg: error.message });
                         this.mysBrowserWindow?.close();
                         this.mysBrowserWindow = null;
                     });

--- a/src/main/service/gachaService.ts
+++ b/src/main/service/gachaService.ts
@@ -1,6 +1,6 @@
 import { app, BrowserWindow, dialog } from 'electron';
-import configService from './ConfigService';
-import settingService from './SettingService';
+import configService from './configService';
+import settingService from './settingService';
 import path from 'path';
 import fs from 'fs';
 

--- a/src/main/service/gachaService.ts
+++ b/src/main/service/gachaService.ts
@@ -4,6 +4,17 @@ import settingService from './settingService';
 import path from 'path';
 import fs from 'fs';
 
+const serverConfigs = {
+    cn: {
+        playerLogPaths: ['../../../LocalLow/miHoYo/崩坏：星穹铁道/Player.log', '../../../LocalLow/miHoYo/崩坏：星穹铁道/Player-prev.log'],
+        urlPattern: /^http.*(?:hkrpg|api).*mihoyo\.com.*?gacha.*\?/i,
+    },
+    global: {
+        playerLogPaths: ['../../../LocalLow/Cognosphere/Star Rail/Player.log', '../../../LocalLow/Cognosphere/Star Rail/Player-prev.log'],
+        urlPattern: /^http.*(?:hkrpg|api).*hoyoverse\.com.*?gacha.*\?/i,
+    },
+};
+
 class GachaService {
     private appDataPath: string;
     private gachaDataPath: string;
@@ -36,6 +47,34 @@ class GachaService {
 
     private loadJson(fName: string) {
         return JSON.parse(fs.readFileSync(path.join(__dirname, `../static/json/${fName}.json`), 'utf-8'));
+    }
+
+    private getGameDataPath(playerLogPath: string) {
+        if (!fs.existsSync(playerLogPath)) return '';
+        const playerLog = fs.readFileSync(playerLogPath, 'utf-8');
+        return playerLog.match(/Loading player data from (.*)data\.unity3d/)?.[1] ?? playerLog.match(/.:\/.+StarRail_Data/)?.[0] ?? '';
+    }
+
+    private getLatestWebCachePath(gameDataPath: string) {
+        const webCachePath = path.join(gameDataPath, './webCaches/');
+        if (!fs.existsSync(webCachePath)) return '';
+        let latestVersion = '0.0.0.0';
+        fs.readdirSync(webCachePath).forEach((fname) => {
+            if (fs.statSync(path.join(webCachePath, fname)).isDirectory() && /\d+\.\d+\.\d+\.\d/.test(fname)) {
+                const latest = latestVersion.split('.');
+                const current = fname.split('.');
+                for (let i = 0; i < 4; ++i) {
+                    if (parseInt(current[i]) > parseInt(latest[i])) {
+                        latestVersion = fname;
+                        break;
+                    } else if (parseInt(current[i]) < parseInt(latest[i])) {
+                        break;
+                    }
+                }
+            }
+        });
+        if (latestVersion === '0.0.0.0') return '';
+        return path.join(webCachePath, latestVersion, 'Cache/Cache_Data/data_2');
     }
 
     public async getGachaUids() {
@@ -312,43 +351,32 @@ class GachaService {
 
     public async getGachaURL(server = 'cn') {
         let url = '';
-        if (server === 'cn') {
-            const playerLogPath = path.join(this.appDataPath, '../../../LocalLow/miHoYo/崩坏：星穹铁道/Player.log');
-            const gameDataPath = fs.readFileSync(playerLogPath, 'utf-8').match(/Loading player data from (.*)data\.unity3d/)[1];
-            const webCachePath = path.join(gameDataPath, './webCaches/');
-            let maxVersion = '0.0.0.0';
-            fs.readdirSync(webCachePath).forEach((fname) => {
-                if (fs.statSync(path.join(webCachePath, fname)).isDirectory() && /\d+\.\d+\.\d+\.\d/.test(fname)) {
-                    const max = maxVersion.split('.');
-                    const now = fname.split('.');
-                    for (let i = 0; i < 4; ++i) {
-                        if (parseInt(now[i]) > parseInt(max[i])) {
-                            maxVersion = fname;
-                            break;
-                        } else if (parseInt(now[i]) < parseInt(max[i])) {
-                            break;
-                        }
-                    }
-                }
-            });
-            if (maxVersion === '0.0.0.0') return { msg: 'URL not found' };
-            const urlWebCachePath = path.join(gameDataPath, `./webCaches/${maxVersion}/Cache/Cache_Data/data_2`);
-            const urlLines = fs.readFileSync(urlWebCachePath, 'utf-8').split('1/0/');
-            urlLines.forEach((line) => {
-                if (line.match(/^http.*(?:hkrpg|api).*mihoyo\.com.*?gacha.*\?/i)) {
-                    url = line.match(/^.*?\x00/)[0].slice(0, -1);
-                }
-            });
-            if (url === '') return { msg: 'URL not found' };
-            const searchKeys = ['authkey_ver', 'authkey', 'game_biz', 'lang'];
-            const urlObj = new URL(url);
-            const params = urlObj.searchParams;
-            const filteredParams = new URLSearchParams(Array.from(params.entries()).filter(([k]) => searchKeys.includes(k)));
-            urlObj.search = filteredParams.toString();
-            return { msg: 'OK', data: { url: urlObj.href } };
-        } else {
+        const serverConfig = serverConfigs[server];
+        if (serverConfig === undefined) {
             return { msg: 'Unsupport server' };
         }
+        const urlWebCachePaths = [];
+        serverConfig.playerLogPaths.forEach((playerLogPath) => {
+            const gameDataPath = this.getGameDataPath(path.join(this.appDataPath, playerLogPath));
+            const urlWebCachePath = gameDataPath ? this.getLatestWebCachePath(gameDataPath) : '';
+            if (urlWebCachePath) urlWebCachePaths.push(urlWebCachePath);
+        });
+        for (const urlWebCachePath of urlWebCachePaths) {
+            const urlLines = fs.readFileSync(urlWebCachePath, 'utf-8').split('1/0/');
+            urlLines.forEach((line) => {
+                if (line.match(serverConfig.urlPattern)) {
+                    url = line.match(/^.*?\x00/)?.[0]?.slice(0, -1) ?? line.match(/^https?:\/\/\S+/)?.[0] ?? '';
+                }
+            });
+            if (url !== '') break;
+        }
+        if (url === '') return { msg: 'URL not found' };
+        const searchKeys = ['authkey_ver', 'authkey', 'sign_type', 'game_biz', 'lang'];
+        const urlObj = new URL(url);
+        const params = urlObj.searchParams;
+        const filteredParams = new URLSearchParams(Array.from(params.entries()).filter(([k]) => searchKeys.includes(k)));
+        urlObj.search = filteredParams.toString();
+        return { msg: 'OK', data: { url: urlObj.href } };
     }
 }
 

--- a/src/main/service/index.ts
+++ b/src/main/service/index.ts
@@ -1,9 +1,9 @@
-import config from './ConfigService';
-import setting from './SettingService';
-import unlockfps from './UnlockFPSService';
-import achievement from './AchievementService';
-import gacha from './GachaService';
-import update from './UpdateService';
+import config from './configService';
+import setting from './settingService';
+import unlockfps from './unlockFPSService';
+import achievement from './achievementService';
+import gacha from './gachaService';
+import update from './updateService';
 
 export default {
     config,

--- a/src/main/service/settingService.ts
+++ b/src/main/service/settingService.ts
@@ -1,4 +1,4 @@
-import configService from './ConfigService';
+import configService from './configService';
 import fs from 'fs';
 
 class SettingService {

--- a/src/renderer/env.d.ts
+++ b/src/renderer/env.d.ts
@@ -27,7 +27,7 @@ declare interface Window {
             exportAchievementData: (uid: string, type: string) => Promise<unknown>;
             importAchievementData: (uid: string, type: string) => Promise<unknown>;
             setAchievementStatus: (uid: string, achievementIds: string[], achievementStatus: number) => Promise<unknown>;
-            refreshAchievementFromMYS: (keepCookie: boolean) => Promise<unknown>;
+            refreshAchievementFromMYS: (keepCookie: boolean, server?: 'cn' | 'global') => Promise<unknown>;
             cancelRefreshAchievementFromMYS: () => Promise<unknown>;
         };
         gacha: {

--- a/src/renderer/env.d.ts
+++ b/src/renderer/env.d.ts
@@ -37,7 +37,7 @@ declare interface Window {
             delGachaData: (uid: string) => Promise<unknown>;
             exportGachaData: (uid: string | string[], type?: string) => Promise<unknown>;
             importGachaData: (type?: string, data?: unknown) => Promise<unknown>;
-            getGachaURL: (server?: string) => Promise<unknown>;
+            getGachaURL: (server?: 'cn' | 'global') => Promise<unknown>;
         };
         update: {
             doDownload: (url: string) => Promise<void>;

--- a/src/renderer/store/usergacha.ts
+++ b/src/renderer/store/usergacha.ts
@@ -102,8 +102,8 @@ export const useUserGacha = defineStore('usergacha', () => {
         return isExportable;
     };
 
-    const getGachaURL = async () => {
-        return await window.fireflyAPI.gacha.getGachaURL();
+    const getGachaURL = async (server: 'cn' | 'global' = 'cn') => {
+        return await window.fireflyAPI.gacha.getGachaURL(server);
     };
 
     const textMapStore = useTextMap();

--- a/src/renderer/views/Achievement/components/AchievementHead.vue
+++ b/src/renderer/views/Achievement/components/AchievementHead.vue
@@ -120,12 +120,19 @@
                         <div class="more-item" @click="(showingAlert = 'refresh'), params.toggleDropdown()">
                             <img class="more-item-icon" :src="RefreshIcon" />
                             <div class="more-item-name">刷新</div>
-                            <Alert v-if="showingAlert === 'refresh'" @close="!isMYSBrowserWindowOpen && (showingAlert = 'none')" title="从米游社刷新/导入">
+                            <Alert v-if="showingAlert === 'refresh'" @close="!isMYSBrowserWindowOpen && (showingAlert = 'none')" title="从官方工具刷新/导入">
+                                <div class="select-item-area">
+                                    <span>服务器：</span>
+                                    <select v-model="selectedAchievementServer">
+                                        <option value="cn">国服</option>
+                                        <option value="global">国际服</option>
+                                    </select>
+                                </div>
                                 <div style="display: flex; gap: 10px; align-items: center">
                                     <Checkbox v-model="refreshAutoLogin" />
                                     自动登录上次的账号（如果凭证还没过期）
                                 </div>
-                                <div class="warning-area" ref="refreshWarningArea">从米游社刷新需要登录米游社账号，只会影响登录账号对应UID的成就存档<br />本次登录仅用于获取成就数据，不会泄漏任何凭证</div>
+                                <div class="warning-area" ref="refreshWarningArea">刷新需要登录对应服务器账号，只会影响登录账号对应UID的成就存档<br />本次登录仅用于获取成就数据，不会泄漏任何凭证</div>
                                 <div class="button-area">
                                     <div class="button" @click="onRefreshCancel">取消</div>
                                     <div class="button theme" @click="onRefreshConfirm">登录</div>
@@ -331,12 +338,13 @@ const onNewlyAlertMounted = () => {
 };
 
 const refreshAutoLogin = ref(true);
+const selectedAchievementServer = ref<'cn' | 'global'>('cn');
 const refreshWarningArea = ref<HTMLSpanElement>(null);
 let isMYSBrowserWindowOpen = false;
 const onRefreshConfirm = async () => {
     if (isMYSBrowserWindowOpen) return;
     isMYSBrowserWindowOpen = true;
-    window.fireflyAPI.achievement.refreshAchievementFromMYS(refreshAutoLogin.value).then((ret) => {
+    window.fireflyAPI.achievement.refreshAchievementFromMYS(refreshAutoLogin.value, selectedAchievementServer.value).then((ret) => {
         isMYSBrowserWindowOpen = false;
         if (/\d+/.test(`${ret}`)) {
             userAchievementStore.init();

--- a/src/renderer/views/Gacha/components/GachaHead.vue
+++ b/src/renderer/views/Gacha/components/GachaHead.vue
@@ -5,6 +5,13 @@
         </div>
         <GachaHeadButton :icon-path="RefreshIcon" btn-title="刷新" btn-class="white" @click="showingAlert = 'refresh'" />
         <Alert id="alert-refresh" v-if="showingAlert === 'refresh'" @close="!isRefreshing && (showingAlert = 'none')" title="刷新记录" @vue:mounted="refreshingItems = []">
+            <div class="select-item-area">
+                <span>服务器：</span>
+                <select v-model="selectedGachaServer">
+                    <option value="cn">国服</option>
+                    <option value="global">国际服</option>
+                </select>
+            </div>
             <div class="url-area" :class="{ shrink: refreshingItems.length > 0 }">
                 <div class="label">URL:</div>
                 <div class="btn" @click="onGetUrlConfirm">自动获取</div>
@@ -142,6 +149,15 @@ const showImportDropdown = ref(false);
 
 const isRefreshing = ref(false);
 const refreshingItems = ref([]);
+const selectedGachaServer = ref<'cn' | 'global'>('cn');
+const gachaServerHosts = {
+    cn: 'mihoyo.com',
+    global: 'hoyoverse.com',
+};
+const gachaServerNames = {
+    cn: '米哈游',
+    global: 'HoYoverse',
+};
 
 const refreshWarningArea = ref<HTMLDivElement>(null);
 const refreshUrlTextarea = ref<HTMLTextAreaElement>(null);
@@ -164,12 +180,12 @@ const onRefreshConfirm = async (isIncremental: boolean) => {
         warningSpan.innerHTML = '<br>URL错误';
         return;
     }
-    if (!urlObj.hostname.endsWith('mihoyo.com') || !urlObj.pathname.match(/gacha/i)) {
-        warningSpan.innerHTML = '<br>非米哈游抽卡分析链接';
+    if (!urlObj.hostname.endsWith(gachaServerHosts[selectedGachaServer.value]) || !urlObj.pathname.match(/gacha/i)) {
+        warningSpan.innerHTML = `<br>非${gachaServerNames[selectedGachaServer.value]}抽卡分析链接`;
         return;
     }
     // 检查URL状态
-    const baseKeys = ['authkey_ver', 'authkey', 'game_biz', 'lang'];
+    const baseKeys = ['authkey_ver', 'authkey', 'sign_type', 'game_biz', 'lang'];
     const baseParams = new URLSearchParams(Array.from(urlObj.searchParams.entries()).filter(([k]) => baseKeys.includes(k)));
     urlObj.search = baseParams.toString() + '&size=20';
     let region_time_zone = 0;
@@ -294,7 +310,7 @@ const onRefreshConfirm = async (isIncremental: boolean) => {
 const onGetUrlConfirm = async () => {
     const warningSpan = refreshWarningArea.value;
     if (isRefreshing.value) return;
-    const ret = await userGachaStore.getGachaURL();
+    const ret = await userGachaStore.getGachaURL(selectedGachaServer.value);
     if (ret['msg'] === 'OK') {
         refreshUrlTextarea.value.value = ret['data']['url'];
         warningSpan.innerHTML = '<br>获取成功，正在检测是否有效';


### PR DESCRIPTION
## 概述

  本 PR 增加对国际服相关数据导入流程的支持，主要解决：

  - #8：支持国际服跃迁记录链接捕捉
  - #13：支持国际服成就从官方工具导入
  
另外修复了一处在Linux下由于大小写敏感导致的构建失败的服务导入路径问题。

  ## 主要改动

  ### 跃迁记录

  - 在跃迁记录刷新弹窗中新增“服务器”选择：
    - 国服
    - 国际服
  - `getGachaURL` 支持按服务器读取不同日志路径：
    - 国服：`miHoYo/崩坏：星穹铁道`
    - 国际服：`Cognosphere/Star Rail`
  - 支持读取 `Player.log` 和 `Player-prev.log`
  - 国际服链接匹配 `hoyoverse.com`
  - 保留国际服链接中的 `sign_type` 参数
  - 手动粘贴链接时会按所选服务器校验域名

  ### 成就导入

  - 在成就刷新/导入弹窗中新增“服务器”选择：
    - 国服
    - 国际服
  - 国服继续使用米游社页面
  - 国际服使用 HoYoLAB 页面
  - 支持拦截：
    - `hoyolab.com/event/rpgcultivate/achievement/list`
    - `hoyoverse.com/event/rpgcultivate/achievement/list`

  ### 构建修复

  - 将主进程服务导入路径调整为与实际文件名一致的小写形式，避免 Linux/macOS/WSL 等大小写敏感文件系统下构建失败。

  ## 验证

已构建并在本机使用本人国际服账户(Asia服务器）进行测试，功能正常

  ## 兼容性

  - 默认服务器仍为国服，现有国服流程保持不变。
  - 未新增全局设置项。
  - 未引入新的依赖。